### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/zookeeper.js
+++ b/zookeeper.js
@@ -19,7 +19,7 @@ syncLimit=2
 function Zookeeper(n) {
   const containers = [];
   for (let i = 0; i < n; i += 1) {
-    containers.push(new Container('zookeeper', image));
+    containers.push(new Container({ name: 'zookeeper', image }));
   }
 
   const zkIDToHostname = {};

--- a/zookeeperExample.js
+++ b/zookeeperExample.js
@@ -11,5 +11,8 @@ const baseMachine = new Machine({
   diskSize: 32,
 });
 
-const infra = new Infrastructure(baseMachine, baseMachine.replicate(n));
+const infra = new Infrastructure({
+  masters: baseMachine,
+  workers: baseMachine.replicate(n),
+});
 zoo.deploy(infra);


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.